### PR TITLE
Added plugin version to js and css files path

### DIFF
--- a/components/Comments.php
+++ b/components/Comments.php
@@ -24,8 +24,8 @@ class Comments extends ComponentBase
 
     public function onRun()
     {
-        $this->controller->addJs('/plugins/dimsog/comments/assets/script.js?20220121');
-        $this->controller->addCss('/plugins/dimsog/comments/assets/style.css');
+        $this->controller->addJs('/plugins/dimsog/comments/assets/script.js', 'Dimsog.Comments');
+        $this->controller->addCss('/plugins/dimsog/comments/assets/style.css', 'Dimsog.Comments');
     }
 
     public function onRender()


### PR DESCRIPTION
Это изменение будет добавлять версию плагина в путь к файлам js и css.
В HTML будет:
```html
<head>
    <link href="https://***.com/plugins/dimsog/comments/assets/style.css?1.0.0" rel="stylesheet">
</head>

[...]

<script src="https://***.com/plugins/dimsog/comments/assets/script.js?1.0.0"></script>
```
Это избавит от проблем с необходимостью чистить кэш браузера в случае изменения css или js.
Доки: https://wintercms.com/docs/services/asset-compilation#injecting-page-assets

Только придётся при изменении js или css файлов изменять версию плагина в `updates\version.yaml`. Я посмотрел, сейчас там прописана версия 1.0.0 при том что в релизах уже 1,0,4
То есть в БД сейчас у плагина версия 1.0.0 и в бэкенде в управлении плагинами показывает версию 1.0.0
А композер смотрит на версию релиза и код скачивает правильно. Короче сейчас несоответствие версии плагина и релиза. Официально у плагина сейчас версия 1.0.0